### PR TITLE
Update meilisearch vectorstore

### DIFF
--- a/docs/docs/integrations/vectorstores/meilisearch.ipynb
+++ b/docs/docs/integrations/vectorstores/meilisearch.ipynb
@@ -10,7 +10,7 @@
     ">\n",
     "> You can [self-host Meilisearch](https://www.meilisearch.com/docs/learn/getting_started/installation#local-installation) or run on [Meilisearch Cloud](https://www.meilisearch.com/pricing).\n",
     "\n",
-    "Meilisearch v1.3 supports vector search. This page guides you through integrating Meilisearch as a vector store and using it to perform vector search.\n",
+    "While Meilisearch has supported vector search since v1.3, this integration is now compatible with Meilisearch v1.11 and includes breaking changes. If you're using Meilisearch v1.3, please use an earlier version of this integration.\n",
     "\n",
     "You'll need to install `langchain-community` with `pip install -qU langchain-community` to use this integration"
    ]
@@ -35,8 +35,8 @@
     "\n",
     "**Host**\n",
     "\n",
-    "- In **local**, the text host is `localhost:7700`\n",
     "- On **Meilisearch Cloud**, find the host in your project _Settings_ page\n",
+    "- In **local**, the text host is `localhost:7700`\n",
     "\n",
     "**API keys**\n",
     "\n",
@@ -64,7 +64,7 @@
    "outputs": [],
    "source": [
     "embedders = { \n",
-    "        \"custom\": {\n",
+    "        \"custom\": { # custom is the name of the embedder\n",
     "            \"source\": \"userProvided\",\n",
     "            \"dimensions\": 1536\n",
     "        }\n",
@@ -162,8 +162,7 @@
     "from langchain_openai import OpenAIEmbeddings\n",
     "from langchain_text_splitters import CharacterTextSplitter\n",
     "\n",
-    "embeddings = OpenAIEmbeddings()\n",
-    "embedder = \"custom\""
+    "embeddings = OpenAIEmbeddings()"
    ]
   },
   {
@@ -186,7 +185,7 @@
    "source": [
     "# Use Meilisearch vector store to store texts & associated embeddings as vector\n",
     "vector_store = Meilisearch.from_texts(\n",
-    "    texts=texts, embedding=embeddings, embedder=embedder\n",
+    "    texts=texts, embedding=embeddings, embedder=\"custom\"\n",
     ")"
    ]
   },
@@ -224,14 +223,14 @@
     "\n",
     "# Import documents & embeddings in the vector store\n",
     "vector_store = Meilisearch.from_documents(\n",
-    "    documents=documents,\n",
+    "    documents=docs,\n",
     "    embedding=embeddings,\n",
-    "    embedder=embedder,\n",
+    "    embedder=\"custom\",\n",
     ")\n",
     "\n",
     "# Search in our vector store\n",
     "query = \"What did the president say about Ketanji Brown Jackson\"\n",
-    "docs = vector_store.similarity_search(query, embedder=embedder)\n",
+    "docs = vector_store.similarity_search(query)\n",
     "print(docs[0].page_content)"
    ]
   },
@@ -263,8 +262,9 @@
     "vector_store = Meilisearch(\n",
     "    embedding=embeddings,\n",
     "    client=client,\n",
-    "    index_name=\"langchain_demo\",\n",
+    "    index_name=\"langchain-demo\",\n",
     "    text_key=\"text\",\n",
+    "    embedder=\"custom\",\n",
     ")\n",
     "vector_store.add_documents(documents)"
    ]
@@ -275,7 +275,7 @@
    "source": [
     "## Similarity Search with score\n",
     "\n",
-    "This specific method allows you to return the documents and the distance score of the query to them. `embedder` is the name of the embedder that should be used for semantic search."
+    "This specific method allows you to return the documents and the distance score of the query to them."
    ]
   },
   {
@@ -285,7 +285,7 @@
    "outputs": [],
    "source": [
     "docs_and_scores = vector_store.similarity_search_with_score(\n",
-    "    query, embedder=embedder\n",
+    "    query\n",
     ")\n",
     "docs_and_scores[0]"
    ]
@@ -306,7 +306,7 @@
    "source": [
     "embedding_vector = embeddings.embed_query(query)\n",
     "docs_and_scores = vector_store.similarity_search_by_vector(\n",
-    "    embedding_vector, embedder=embedder\n",
+    "    embedding_vector\n",
     ")\n",
     "docs_and_scores[0]"
    ]

--- a/docs/docs/integrations/vectorstores/meilisearch.ipynb
+++ b/docs/docs/integrations/vectorstores/meilisearch.ipynb
@@ -63,12 +63,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "embedders = { \n",
-    "        \"custom\": { # custom is the name of the embedder\n",
-    "            \"source\": \"userProvided\",\n",
-    "            \"dimensions\": 1536\n",
-    "        }\n",
+    "import meilisearch\n",
+    "\n",
+    "client = meilisearch.Client(url=\"http://127.0.0.1:7700\", api_key=\"***\")\n",
+    "index_uid = \"langchain-demo\"\n",
+    "embedders = {\n",
+    "    \"custom\": {  # custom is the name of the embedder\n",
+    "        \"source\": \"userProvided\",\n",
+    "        \"dimensions\": 1536,\n",
     "    }\n",
+    "}\n",
     "embedders_update = client.index(index_uid).update_embedders(embedders)\n",
     "client.index(index_uid).wait_for_task(embedders_update.task_uid)"
    ]
@@ -284,9 +288,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "docs_and_scores = vector_store.similarity_search_with_score(\n",
-    "    query\n",
-    ")\n",
+    "docs_and_scores = vector_store.similarity_search_with_score(query)\n",
     "docs_and_scores[0]"
    ]
   },
@@ -305,9 +307,7 @@
    "outputs": [],
    "source": [
     "embedding_vector = embeddings.embed_query(query)\n",
-    "docs_and_scores = vector_store.similarity_search_by_vector(\n",
-    "    embedding_vector\n",
-    ")\n",
+    "docs_and_scores = vector_store.similarity_search_by_vector(embedding_vector)\n",
     "docs_and_scores[0]"
    ]
   },

--- a/docs/docs/integrations/vectorstores/meilisearch.ipynb
+++ b/docs/docs/integrations/vectorstores/meilisearch.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "**Host**\n",
     "\n",
-    "- In **local**, the default host is `localhost:7700`\n",
+    "- In **local**, the text host is `localhost:7700`\n",
     "- On **Meilisearch Cloud**, find the host in your project _Settings_ page\n",
     "\n",
     "**API keys**\n",
@@ -46,6 +46,31 @@
     "- A `SEARCH KEY` — a key that you can safely share in front-end applications\n",
     "\n",
     "You can create [additional API keys](https://www.meilisearch.com/docs/learn/security/master_api_keys) as needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configuring the embedder\n",
+    "\n",
+    "Make sure you have an [embedder configured](https://www.meilisearch.com/docs/reference/api/settings#embedders-experimental) in your Meilisearch instance. You can configure the embedder in the Meilisearch dashboard or using the Meilisearch Python SDK."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embedders = { \n",
+    "        \"custom\": {\n",
+    "            \"source\": \"userProvided\",\n",
+    "            \"dimensions\": 1536\n",
+    "        }\n",
+    "    }\n",
+    "embedders_update = client.index(index_uid).update_embedders(embedders)\n",
+    "client.index(index_uid).wait_for_task(embedders_update.task_uid)"
    ]
   },
   {
@@ -138,13 +163,7 @@
     "from langchain_text_splitters import CharacterTextSplitter\n",
     "\n",
     "embeddings = OpenAIEmbeddings()\n",
-    "embedders = {\n",
-    "    \"default\": {\n",
-    "        \"source\": \"userProvided\",\n",
-    "        \"dimensions\": 1536,\n",
-    "    }\n",
-    "}\n",
-    "embedder_name = \"default\""
+    "embedder = \"custom\""
    ]
   },
   {
@@ -167,7 +186,7 @@
    "source": [
     "# Use Meilisearch vector store to store texts & associated embeddings as vector\n",
     "vector_store = Meilisearch.from_texts(\n",
-    "    texts=texts, embedding=embeddings, embedders=embedders, embedder_name=embedder_name\n",
+    "    texts=texts, embedding=embeddings, embedder=embedder\n",
     ")"
    ]
   },
@@ -207,13 +226,12 @@
     "vector_store = Meilisearch.from_documents(\n",
     "    documents=documents,\n",
     "    embedding=embeddings,\n",
-    "    embedders=embedders,\n",
-    "    embedder_name=embedder_name,\n",
+    "    embedder=embedder,\n",
     ")\n",
     "\n",
     "# Search in our vector store\n",
     "query = \"What did the president say about Ketanji Brown Jackson\"\n",
-    "docs = vector_store.similarity_search(query, embedder_name=embedder_name)\n",
+    "docs = vector_store.similarity_search(query, embedder=embedder)\n",
     "print(docs[0].page_content)"
    ]
   },
@@ -241,9 +259,9 @@
     "from langchain_community.vectorstores import Meilisearch\n",
     "\n",
     "client = meilisearch.Client(url=\"http://127.0.0.1:7700\", api_key=\"***\")\n",
+    "\n",
     "vector_store = Meilisearch(\n",
     "    embedding=embeddings,\n",
-    "    embedders=embedders,\n",
     "    client=client,\n",
     "    index_name=\"langchain_demo\",\n",
     "    text_key=\"text\",\n",
@@ -257,7 +275,7 @@
    "source": [
     "## Similarity Search with score\n",
     "\n",
-    "This specific method allows you to return the documents and the distance score of the query to them. `embedder_name` is the name of the embedder that should be used for semantic search, defaults to \"default\"."
+    "This specific method allows you to return the documents and the distance score of the query to them. `embedder` is the name of the embedder that should be used for semantic search."
    ]
   },
   {
@@ -267,7 +285,7 @@
    "outputs": [],
    "source": [
     "docs_and_scores = vector_store.similarity_search_with_score(\n",
-    "    query, embedder_name=embedder_name\n",
+    "    query, embedder=embedder\n",
     ")\n",
     "docs_and_scores[0]"
    ]
@@ -277,7 +295,7 @@
    "metadata": {},
    "source": [
     "## Similarity Search by vector\n",
-    "`embedder_name` is the name of the embedder that should be used for semantic search, defaults to \"default\"."
+    "`embedder` is the name of the embedder that should be used for semantic search."
    ]
   },
   {
@@ -288,7 +306,7 @@
    "source": [
     "embedding_vector = embeddings.embed_query(query)\n",
     "docs_and_scores = vector_store.similarity_search_by_vector(\n",
-    "    embedding_vector, embedder_name=embedder_name\n",
+    "    embedding_vector, embedder=embedder\n",
     ")\n",
     "docs_and_scores[0]"
    ]

--- a/libs/community/langchain_community/vectorstores/meilisearch.py
+++ b/libs/community/langchain_community/vectorstores/meilisearch.py
@@ -131,7 +131,7 @@ class Meilisearch(VectorStore):
             docs.append(
                 {
                     "id": id,
-                    "_vectors": {f"{embedder}": embedding},
+                    "_vectors": {embedder: embedding},
                     f"{self._metadata_key}": metadata,
                 }
             )

--- a/libs/community/langchain_community/vectorstores/meilisearch.py
+++ b/libs/community/langchain_community/vectorstores/meilisearch.py
@@ -97,14 +97,14 @@ class Meilisearch(VectorStore):
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
         ids: Optional[List[str]] = None,
-        embedder_name: Optional[str] = "default",
+        embedder: str = "default",
         **kwargs: Any,
     ) -> List[str]:
         """Run more texts through the embedding and add them to the vector store.
 
         Args:
             texts (Iterable[str]): Iterable of strings/text to add to the vectorstore.
-            embedder_name: Name of the embedder. Defaults to "default".
+            embedder: Name of the embedder. Defaults to "default".
             metadatas (Optional[List[dict]]): Optional list of metadata.
                 Defaults to None.
             ids Optional[List[str]]: Optional list of IDs.
@@ -131,7 +131,7 @@ class Meilisearch(VectorStore):
             docs.append(
                 {
                     "id": id,
-                    "_vectors": {f"{embedder_name}": embedding},
+                    "_vectors": {f"{embedder}": embedding},
                     f"{self._metadata_key}": metadata,
                 }
             )
@@ -145,14 +145,14 @@ class Meilisearch(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Dict[str, str]] = None,
-        embedder_name: Optional[str] = "default",
+        embedder: str = "default",
         **kwargs: Any,
     ) -> List[Document]:
         """Return meilisearch documents most similar to the query.
 
         Args:
             query (str): Query text for which to find similar documents.
-            embedder_name: Name of the embedder to be used. Defaults to "default".
+            embedder: Name of the embedder to be used. Defaults to "default".
             k (int): Number of documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata.
                 Defaults to None.
@@ -163,7 +163,7 @@ class Meilisearch(VectorStore):
         """
         docs_and_scores = self.similarity_search_with_score(
             query=query,
-            embedder_name=embedder_name,
+            embedder=embedder,
             k=k,
             filter=filter,
             kwargs=kwargs,
@@ -175,14 +175,14 @@ class Meilisearch(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Dict[str, str]] = None,
-        embedder_name: Optional[str] = "default",
+        embedder: str = "default",
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return meilisearch documents most similar to the query, along with scores.
 
         Args:
             query (str): Query text for which to find similar documents.
-            embedder_name: Name of the embedder to be used. Defaults to "default".
+            embedder: Name of the embedder to be used. Defaults to "default".
             k (int): Number of documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata.
                 Defaults to None.
@@ -195,7 +195,7 @@ class Meilisearch(VectorStore):
 
         docs = self.similarity_search_by_vector_with_scores(
             embedding=_query,
-            embedder_name=embedder_name,
+            embedder=embedder,
             k=k,
             filter=filter,
             kwargs=kwargs,
@@ -205,7 +205,7 @@ class Meilisearch(VectorStore):
     def similarity_search_by_vector_with_scores(
         self,
         embedding: List[float],
-        embedder_name: Optional[str] = "default",
+        embedder: str = "default",
         k: int = 4,
         filter: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
@@ -214,7 +214,7 @@ class Meilisearch(VectorStore):
 
         Args:
             embedding (List[float]): Embedding to look up similar documents.
-            embedder_name: Name of the embedder to be used. Defaults to "default".
+            embedder: Name of the embedder to be used. Defaults to "default".
             k (int): Number of documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata.
                 Defaults to None.
@@ -228,7 +228,7 @@ class Meilisearch(VectorStore):
             "",
             {
                 "vector": embedding,
-                "hybrid": {"semanticRatio": 1.0, "embedder": embedder_name},
+                "hybrid": {"semanticRatio": 1.0, "embedder": embedder},
                 "limit": k,
                 "filter": filter,
                 "showRankingScore": True,
@@ -251,14 +251,14 @@ class Meilisearch(VectorStore):
         embedding: List[float],
         k: int = 4,
         filter: Optional[Dict[str, str]] = None,
-        embedder_name: Optional[str] = "default",
+        embedder: str = "default",
         **kwargs: Any,
     ) -> List[Document]:
         """Return meilisearch documents most similar to embedding vector.
 
         Args:
             embedding (List[float]): Embedding to look up similar documents.
-            embedder_name: Name of the embedder to be used. Defaults to "default".
+            embedder: Name of the embedder to be used. Defaults to "default".
             k (int): Number of documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata.
                 Defaults to None.
@@ -269,7 +269,7 @@ class Meilisearch(VectorStore):
         """
         docs = self.similarity_search_by_vector_with_scores(
             embedding=embedding,
-            embedder_name=embedder_name,
+            embedder=embedder,
             k=k,
             filter=filter,
             kwargs=kwargs,
@@ -289,7 +289,7 @@ class Meilisearch(VectorStore):
         ids: Optional[List[str]] = None,
         text_key: Optional[str] = "text",
         metadata_key: Optional[str] = "metadata",
-        embedder_name: Optional[str] = "default",
+        embedder: str = "default",
         **kwargs: Any,
     ) -> Meilisearch:
         """Construct Meilisearch wrapper from raw documents.
@@ -311,7 +311,7 @@ class Meilisearch(VectorStore):
                 # in your Meilisearch console
                 client = meilisearch.Client(url='http://127.0.0.1:7700', api_key='***')
                 embedding = OpenAIEmbeddings()
-                embedder_name: Name of the embedder. Defaults to "default".
+                embedder: Name of the embedder. Defaults to "default".
                 docsearch = Meilisearch.from_texts(
                     client=client,
                     embedding=embedding,
@@ -326,7 +326,7 @@ class Meilisearch(VectorStore):
         )
         vectorstore.add_texts(
             texts=texts,
-            embedder_name=embedder_name,
+            embedder=embedder,
             metadatas=metadatas,
             ids=ids,
             text_key=text_key,

--- a/libs/community/langchain_community/vectorstores/meilisearch.py
+++ b/libs/community/langchain_community/vectorstores/meilisearch.py
@@ -65,15 +65,9 @@ class Meilisearch(VectorStore):
             # api_key is optional; provide it if your meilisearch instance requires it
             client = meilisearch.Client(url='http://127.0.0.1:7700', api_key='***')
             embeddings = OpenAIEmbeddings()
-            embedders = {
-                "theEmbedderName": {
-                    "source": "userProvided",
-                    "dimensions": "1536"
-                }
-            }
+
             vectorstore = Meilisearch(
                 embedding=embeddings,
-                embedders=embedders,
                 client=client,
                 index_name='langchain_demo',
                 text_key='text')
@@ -88,8 +82,6 @@ class Meilisearch(VectorStore):
         index_name: str = "langchain-demo",
         text_key: str = "text",
         metadata_key: str = "metadata",
-        *,
-        embedders: Optional[Dict[str, Any]] = None,
     ):
         """Initialize with Meilisearch client."""
         client = _create_client(client=client, url=url, api_key=api_key)
@@ -99,10 +91,6 @@ class Meilisearch(VectorStore):
         self._embedding = embedding
         self._text_key = text_key
         self._metadata_key = metadata_key
-        self._embedders = embedders
-        self._embedders_settings = self._client.index(
-            str(self._index_name)
-        ).update_embedders(embedders)
 
     def add_texts(
         self,
@@ -301,7 +289,6 @@ class Meilisearch(VectorStore):
         ids: Optional[List[str]] = None,
         text_key: Optional[str] = "text",
         metadata_key: Optional[str] = "metadata",
-        embedders: Dict[str, Any] = {},
         embedder_name: Optional[str] = "default",
         **kwargs: Any,
     ) -> Meilisearch:
@@ -324,7 +311,6 @@ class Meilisearch(VectorStore):
                 # in your Meilisearch console
                 client = meilisearch.Client(url='http://127.0.0.1:7700', api_key='***')
                 embedding = OpenAIEmbeddings()
-                embedders: Embedders index setting.
                 embedder_name: Name of the embedder. Defaults to "default".
                 docsearch = Meilisearch.from_texts(
                     client=client,
@@ -335,7 +321,6 @@ class Meilisearch(VectorStore):
 
         vectorstore = cls(
             embedding=embedding,
-            embedders=embedders,
             client=client,
             index_name=index_name,
         )

--- a/libs/community/langchain_community/vectorstores/meilisearch.py
+++ b/libs/community/langchain_community/vectorstores/meilisearch.py
@@ -97,14 +97,14 @@ class Meilisearch(VectorStore):
         texts: Iterable[str],
         metadatas: Optional[List[dict]] = None,
         ids: Optional[List[str]] = None,
-        embedder: str = "default",
+        embedder: str,
         **kwargs: Any,
     ) -> List[str]:
         """Run more texts through the embedding and add them to the vector store.
 
         Args:
             texts (Iterable[str]): Iterable of strings/text to add to the vectorstore.
-            embedder: Name of the embedder. Defaults to "default".
+            embedder: Name of the embedder.
             metadatas (Optional[List[dict]]): Optional list of metadata.
                 Defaults to None.
             ids Optional[List[str]]: Optional list of IDs.
@@ -145,14 +145,14 @@ class Meilisearch(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Dict[str, str]] = None,
-        embedder: str = "default",
+        embedder: str,
         **kwargs: Any,
     ) -> List[Document]:
         """Return meilisearch documents most similar to the query.
 
         Args:
             query (str): Query text for which to find similar documents.
-            embedder: Name of the embedder to be used. Defaults to "default".
+            embedder: Name of the embedder to be used.
             k (int): Number of documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata.
                 Defaults to None.
@@ -175,14 +175,14 @@ class Meilisearch(VectorStore):
         query: str,
         k: int = 4,
         filter: Optional[Dict[str, str]] = None,
-        embedder: str = "default",
+        embedder: str,
         **kwargs: Any,
     ) -> List[Tuple[Document, float]]:
         """Return meilisearch documents most similar to the query, along with scores.
 
         Args:
             query (str): Query text for which to find similar documents.
-            embedder: Name of the embedder to be used. Defaults to "default".
+            embedder: Name of the embedder to be used.
             k (int): Number of documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata.
                 Defaults to None.
@@ -205,7 +205,7 @@ class Meilisearch(VectorStore):
     def similarity_search_by_vector_with_scores(
         self,
         embedding: List[float],
-        embedder: str = "default",
+        embedder: str,
         k: int = 4,
         filter: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
@@ -214,7 +214,7 @@ class Meilisearch(VectorStore):
 
         Args:
             embedding (List[float]): Embedding to look up similar documents.
-            embedder: Name of the embedder to be used. Defaults to "default".
+            embedder: Name of the embedder to be used.
             k (int): Number of documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata.
                 Defaults to None.
@@ -251,14 +251,14 @@ class Meilisearch(VectorStore):
         embedding: List[float],
         k: int = 4,
         filter: Optional[Dict[str, str]] = None,
-        embedder: str = "default",
+        embedder: str,
         **kwargs: Any,
     ) -> List[Document]:
         """Return meilisearch documents most similar to embedding vector.
 
         Args:
             embedding (List[float]): Embedding to look up similar documents.
-            embedder: Name of the embedder to be used. Defaults to "default".
+            embedder: Name of the embedder to be used.
             k (int): Number of documents to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata.
                 Defaults to None.
@@ -289,7 +289,7 @@ class Meilisearch(VectorStore):
         ids: Optional[List[str]] = None,
         text_key: Optional[str] = "text",
         metadata_key: Optional[str] = "metadata",
-        embedder: str = "default",
+        embedder: str,
         **kwargs: Any,
     ) -> Meilisearch:
         """Construct Meilisearch wrapper from raw documents.
@@ -311,7 +311,7 @@ class Meilisearch(VectorStore):
                 # in your Meilisearch console
                 client = meilisearch.Client(url='http://127.0.0.1:7700', api_key='***')
                 embedding = OpenAIEmbeddings()
-                embedder: Name of the embedder. Defaults to "default".
+                embedder: Name of the embedder.
                 docsearch = Meilisearch.from_texts(
                     client=client,
                     embedding=embedding,

--- a/libs/community/tests/integration_tests/vectorstores/test_meilisearch.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_meilisearch.py
@@ -1,6 +1,6 @@
 """Test Meilisearch functionality."""
 
-from typing import TYPE_CHECKING, Any, Dict, Generator
+from typing import TYPE_CHECKING, Generator
 
 import pytest
 import requests
@@ -57,7 +57,7 @@ class TestMeilisearchVectorSearch:
         import meilisearch
 
         return meilisearch.Client(TEST_MEILI_HTTP_ADDR, TEST_MEILI_MASTER_KEY)
-    
+
     def setup_embedder(self) -> None:
         client = self.client()
         embedders = {

--- a/libs/community/tests/integration_tests/vectorstores/test_meilisearch.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_meilisearch.py
@@ -84,7 +84,7 @@ class TestMeilisearchVectorSearch:
         vectorstore = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder_name="default",
+            embedder="default",
             url=TEST_MEILI_HTTP_ADDR,
             api_key=TEST_MEILI_MASTER_KEY,
             index_name=INDEX_NAME,
@@ -99,7 +99,7 @@ class TestMeilisearchVectorSearch:
         vectorstore = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder_name="default",
+            embedder="default",
             client=self.client(),
             index_name=INDEX_NAME,
         )
@@ -114,7 +114,7 @@ class TestMeilisearchVectorSearch:
         docsearch = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder_name="default",
+            embedder="default",
             url=TEST_MEILI_HTTP_ADDR,
             api_key=TEST_MEILI_MASTER_KEY,
             index_name=INDEX_NAME,
@@ -134,7 +134,7 @@ class TestMeilisearchVectorSearch:
         docsearch = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder_name="default",
+            embedder="default",
             url=TEST_MEILI_HTTP_ADDR,
             api_key=TEST_MEILI_MASTER_KEY,
             index_name=INDEX_NAME,
@@ -153,7 +153,7 @@ class TestMeilisearchVectorSearch:
         docsearch = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder_name="default",
+            embedder="default",
             url=TEST_MEILI_HTTP_ADDR,
             api_key=TEST_MEILI_MASTER_KEY,
             index_name=INDEX_NAME,

--- a/libs/community/tests/integration_tests/vectorstores/test_meilisearch.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_meilisearch.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 INDEX_NAME = "test-langchain-demo"
 TEST_MEILI_HTTP_ADDR = "http://localhost:7700"
 TEST_MEILI_MASTER_KEY = "masterKey"
+EMBEDDER = "default"
 
 
 class TestMeilisearchVectorSearch:
@@ -61,7 +62,7 @@ class TestMeilisearchVectorSearch:
     def setup_embedder(self) -> None:
         client = self.client()
         embedders = {
-            "default": {
+            EMBEDDER: {
                 "source": "userProvided",
                 "dimensions": 10,
             }
@@ -82,7 +83,7 @@ class TestMeilisearchVectorSearch:
         vectorstore = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder="default",
+            embedder=EMBEDDER,
             url=TEST_MEILI_HTTP_ADDR,
             api_key=TEST_MEILI_MASTER_KEY,
             index_name=INDEX_NAME,
@@ -97,7 +98,7 @@ class TestMeilisearchVectorSearch:
         vectorstore = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder="default",
+            embedder=EMBEDDER,
             client=self.client(),
             index_name=INDEX_NAME,
         )
@@ -112,7 +113,7 @@ class TestMeilisearchVectorSearch:
         docsearch = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder="default",
+            embedder=EMBEDDER,
             url=TEST_MEILI_HTTP_ADDR,
             api_key=TEST_MEILI_MASTER_KEY,
             index_name=INDEX_NAME,
@@ -132,7 +133,7 @@ class TestMeilisearchVectorSearch:
         docsearch = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder="default",
+            embedder=EMBEDDER,
             url=TEST_MEILI_HTTP_ADDR,
             api_key=TEST_MEILI_MASTER_KEY,
             index_name=INDEX_NAME,
@@ -151,7 +152,7 @@ class TestMeilisearchVectorSearch:
         docsearch = Meilisearch.from_texts(
             texts=texts,
             embedding=FakeEmbeddings(),
-            embedder="default",
+            embedder=EMBEDDER,
             url=TEST_MEILI_HTTP_ADDR,
             api_key=TEST_MEILI_MASTER_KEY,
             index_name=INDEX_NAME,


### PR DESCRIPTION
- Remove embedder settings update
- Rename embedder_name to embedder for consistency with Meilisearch naming and make it mandatory for compatibility with v1.11
- Update tests
- Update notebook documentation
- Add embedder to Meilisearch vectorstore initialization